### PR TITLE
rename remove to deleteConnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rutter-client",
-  "version": "1.2.1",
+  "version": "1.2.5",
   "description": "Unofficial rutter's REST APIs client",
   "main": "dist/index.js",
   "author": "Asdullah Siddique",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rutter-client",
-  "version": "1.2.5",
+  "version": "1.2.4",
   "description": "Unofficial rutter's REST APIs client",
   "main": "dist/index.js",
   "author": "Asdullah Siddique",

--- a/src/connection/__test__/connection.test.js
+++ b/src/connection/__test__/connection.test.js
@@ -47,12 +47,12 @@ describe('Connection APIs', () => {
     expect(scope.isDone()).toBeTruthy();
   });
 
-  it('consumes delete connection API', async () => {
+  it('consumes remove connection API', async () => {
     const connectionId = '123';
     const scope = nock(defaults.API_ENDPOINT)
-      .delete(`/connections/${connectionId}`)
+      .remove(`/connections/${connectionId}`)
       .reply(200, {});
-    await client.connection.delete({ connectionId });
+    await client.connection.remove({ connectionId });
     expect(scope.isDone()).toBeTruthy();
   });
 });

--- a/src/connection/__test__/connection.test.js
+++ b/src/connection/__test__/connection.test.js
@@ -47,12 +47,12 @@ describe('Connection APIs', () => {
     expect(scope.isDone()).toBeTruthy();
   });
 
-  it('consumes remove connection API', async () => {
+  it('consumes delete connection API', async () => {
     const connectionId = '123';
     const scope = nock(defaults.API_ENDPOINT)
-      .remove(`/connections/${connectionId}`)
+      .delete(`/connections/${connectionId}`)
       .reply(200, {});
-    await client.connection.remove({ connectionId });
+    await client.connection.deleteConnection({ connectionId });
     expect(scope.isDone()).toBeTruthy();
   });
 });

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -159,7 +159,7 @@ ConnectionClient.prototype.create = async function create(options) {
  * @throws {Error}
  * @throws {import("../RutterError").RutterError}
  */
-ConnectionClient.prototype.remove = async function remove({ connectionId }) {
+ConnectionClient.prototype.deleteConnection = async function deleteConnection({ connectionId }) {
   return this.client.request({
     method: 'delete',
     url: `/connections/${connectionId}`,

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -159,7 +159,7 @@ ConnectionClient.prototype.create = async function create(options) {
  * @throws {Error}
  * @throws {import("../RutterError").RutterError}
  */
-ConnectionClient.prototype.remove = async function removeß({ connectionId }) {
+ConnectionClient.prototype.remove = async function remove({ connectionId }) {
   return this.client.request({
     method: 'delete',
     url: `/connections/${connectionId}`,


### PR DESCRIPTION
Rename `remove` to `deleteConnection` to avoid conflicts and fixed a typo